### PR TITLE
mintページの機能修正

### DIFF
--- a/const/contractAddresses.ts
+++ b/const/contractAddresses.ts
@@ -2,7 +2,7 @@
 
 // 1. Set up the network your smart contracts are deployed to.
 // First, import the chain from the package, then set the NETWORK variable to the chain.
-import { Mumbai } from "@thirdweb-dev/chains";
+// import { Mumbai } from "@thirdweb-dev/chains";
 import { Astar } from "@thirdweb-dev/chains";
 // export const NETWORK = Mumbai;
 export const NETWORK = Astar;
@@ -12,14 +12,16 @@ export const NETWORK = Astar;
 export const MARKETPLACE_ADDRESS =
 //  "0x6604bd9D7770035f26B4ACeab2C746fdCE166473";テンプレのアドレス
 // "0x6C3C83D94091ED039521505D896cC87F9642Aa36"; //munbaiのアドレス
-"0xD47c697A162365edafB7E2657108a225e93410eD";
+// "0xD47c697A162365edafB7E2657108a225e93410eD"; //test astar
+"0xd3FBa9354B29B2bBCce80552D2E0389B941bC2C3"; //test2 astar
 
 
 // 3. The address of your NFT collection smart contract.
 export const NFT_COLLECTION_ADDRESS =
   // "0xFfd9bAddF3f6e427EfAa1A4AEC99131078C1d683";　テンプレのアドレス
   // "0xA181CA2fe0Fb26d493B83b9e34974ddF1af7b6fE"; //munbaiのアドレス
-  "0x37F27DaAB6fcf4f8Fbbf961ba0C28E283B2d31A0";
+  // "0x37F27DaAB6fcf4f8Fbbf961ba0C28E283B2d31A0";  //test astar
+  "0x3Bb860F2a09AdcFaDd8716D9a245797FcA4a3147";//test2 astar
 
 // (Optional) Set up the URL of where users can view transactions on
 // For example, below, we use Mumbai.polygonscan to view transactions on the Mumbai testnet.


### PR DESCRIPTION
Make NFTを作った後、
・Successのトーストを出すようにし、その1秒後にbuy画面へredirectするようにした。（sellの方がいいか？）
・NFTのサムネ画像を/public配下の画像から選べるようにした。
　これによってサムネイルをinputする過程を秘匿することができる。
・descriptionを追加するようにした。

